### PR TITLE
feat(): be able to see shifts again before confirming

### DIFF
--- a/src/root/Engagement/Schedule/Priority.js
+++ b/src/root/Engagement/Schedule/Priority.js
@@ -28,7 +28,7 @@ import {
 import {div} from 'helpers'
 
 import {
-  ShiftContent,
+  ShiftContentExtra,
 } from 'components/shift'
 
 const ListItemCheckboxDisabling = sources => {
@@ -60,7 +60,7 @@ const ListItemCheckboxDisabling = sources => {
 }
 
 const ShiftItem = sources => {
-  const content = ShiftContent(sources)
+  const content = ShiftContentExtra(sources)
   const shiftKey$ = sources.item$.pluck('$key')
 
   const assignment$ = sources.assignments$
@@ -129,7 +129,7 @@ const AssignedShiftItem = sources => {
     ,
   }
 
-  const content = ShiftContent({..._sources,
+  const content = ShiftContentExtra({..._sources,
     item$: _sources.shift$,
   })
 


### PR DESCRIPTION
This will make my life so much easier. Its pretty often that people don't want to pay
until they see their shifts again, but I currently have no way to see what shifts they
have selected until they are confirmed.
