### PR TITLE
fix(Organizers): Do not check organizer email matches invite email

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We're not just a volunteer management app, and we're not just a craigslist for v
 
 ### Ethos
 
-Volunterism is a fundamental part of our company ethos, and open source is just another expression of that.  As we continue to develop this application, we are constantly looking for ways to extract things into more reusable libraries that we can give back to the community.  If you see anything like that in the code, open an issue and let us know!
+Volunterism is a fundamental part of our company ethos, and open source is just another expression of that.  As we continue to develop this application, we are constantly looking for ways to extract things into more reusable libraries that we can give back jto the community.  If you see anything like that in the code, open an issue and let us know!
 
 ### Contributions
 

--- a/src/root/Organize/index.js
+++ b/src/root/Organize/index.js
@@ -107,31 +107,21 @@ export default _sources => {
   const accepted$ = sources.organizer$
     .filter(prop('isAccepted'))
 
-  const emailMatches$ = $.combineLatest(
-    loggedIn$.map(prop('email')),
-    notAccepted$.map(prop('inviteEmail')),
-    equals
-  )
-
   const profileMatches$ = $.combineLatest(
     loggedIn$.map(prop('key')),
     accepted$.map(prop('profileKey')),
     equals
   )
 
+  // One of these these stremas emits:
   const notLoggedinNotAccepted$ = $.combineLatest(notLoggedin$, notAccepted$)
     .map(loginButtons)
 
   const notLoggedInAccepted$ = $.combineLatest(notLoggedin$, accepted$)
     .map({DOM: just(h5('This invite has already been accepted.'))})
 
-  const showAccept$ = emailMatches$
-    .filter(Boolean)
+  const showAccept$ = $.combineLatest(loggedIn$, notAccepted$)
     .map(acceptButton)
-
-  const notForYou$ = emailMatches$
-    .filter(complement(Boolean))
-    .map({DOM: just(h5('This invite is not for you.'))})
 
   const alreadyAccepted$ = profileMatches$
     .filter(Boolean)
@@ -156,7 +146,6 @@ export default _sources => {
     notLoggedinNotAccepted$,
     notLoggedInAccepted$,
     showAccept$,
-    notForYou$,
     alreadyAccepted$,
     anotherAccepted$
   ).shareReplay(1)


### PR DESCRIPTION
Organizers should be able to accept an invite regardless of the email
address that it was orginally sent to.
