### PR TITLE
fix(openAndPrint): fix for open and print driver

### DIFF
--- a/src/drivers/openAndPrint.js
+++ b/src/drivers/openAndPrint.js
@@ -1,38 +1,32 @@
 import {Observable} from 'rx'
 
-function buildHtml(html, style) {
+function buildHtml(html) {
   return `
-  <html>
-    <head>
-      <style>
-        ${style}
-      </style>
-    </head>
-    <body>
-      ${html}
-    </body>
-  </html>
-  `
+<html>
+  <head>
+    ${document.head.innerHTML}
+  </head>
+  <body>
+    ${html}
+  </body>
+</html>
+`
 }
 
 export default function openAndPrintDriver(html$) {
-  const style = Array.prototype.slice.call(document.querySelectorAll('style'))
-    .map(x => x.innerHTML)
-    .reduce(function concatStrings(x, y) { return x + y}, '')
-
   html$
+    .map(buildHtml)
     .subscribe(html => {
       const WinPrint = window.open('', '', 'left=0,top=0,width=800,height=900,toolbar=0,scrollbars=0,status=0') // eslint-disable-line max-len
-      WinPrint.document.write(buildHtml(html, style))
+      WinPrint.document.write(html)
       WinPrint.document.close()
       WinPrint.focus()
-      // no idea why, but all of the sudden the printed reports were f'd
-      // trial and error determined that putting print/close in a timeout
-      // gave browser enough time to render page correctly?
-      setTimeout(function printIt() {
+
+      // setTimeout is required for parsing of stylesheets
+      setTimeout(() => {
         WinPrint.print()
         WinPrint.close()
-      },0)
+      })
     })
 
   return Observable.empty()


### PR DESCRIPTION
The styles of a page are now loaded in many different ways, this ensures that
the print page shares all of the same style that the main application does.
