### PR TITLE
fix(openAndPrint): use the current page for printing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+/* global Sparks */
 import {run} from '@cycle/core'
 
 // drivers
@@ -11,7 +12,7 @@ import {
   makeAuthDriver, makeFirebaseDriver, makeQueueDriver,
 } from '@sparksnetwork/cyclic-fire'
 import screenInfoDriver from 'drivers/screenInfo'
-import openAndPrintDriver from 'drivers/openAndPrint'
+import makeOpenAndPrintDriver from 'drivers/openAndPrint'
 import makeBugsnagDriver from 'drivers/bugsnag'
 import makeFocusNextDriver from 'drivers/focusNext'
 import makePrerenderDriver from 'drivers/prerender'
@@ -27,9 +28,9 @@ try {
   firebase.app()
 } catch (err) {
   firebase.initializeApp({
-    apiKey: Sparks.FIREBASE_API_KEY, // eslint-disable-line
-    authDomain: Sparks.FIREBASE_AUTH_DOMAIN, // eslint-disable-line
-    databaseURL: Sparks.FIREBASE_DATABASE_URL, // eslint-disable-line
+    apiKey: Sparks.FIREBASE_API_KEY,
+    authDomain: Sparks.FIREBASE_AUTH_DOMAIN,
+    databaseURL: Sparks.FIREBASE_DATABASE_URL,
   })
 }
 const fbRoot = firebase.database().ref()
@@ -47,7 +48,7 @@ const {sources, sinks} = run(Root, {
   bugsnag: makeBugsnagDriver({
     releaseStage: process.env.BUILD_ENV || 'development',
   }),
-  openAndPrint: openAndPrintDriver,
+  openAndPrint: makeOpenAndPrintDriver('#root'),
   prerender: makePrerenderDriver(),
   openGraph: makeOpenGraphDriver(),
 })

--- a/src/root/index.js
+++ b/src/root/index.js
@@ -100,7 +100,9 @@ const Root = sources => {
     navDOM$: nav.DOM,
   })
 
-  const DOM = page.DOM
+  const _DOM = page.DOM.shareReplay(1)
+  // when done with printing reattach event liteners
+  const DOM = _DOM.merge(_DOM.sample(sources.openAndPrint))
 
   const auth$ = page.auth$
 


### PR DESCRIPTION
The open and print driver will now use the current page, including
all of it's loaded CSS, to ensure that the part of the page we want
to render is styled correctly.

There is a small hack between the openAndPrint driver and the DOM driver
in order to ensure that event handlers continue to work. For instance, if
you do not 'rerender', the print button will not work after closing the print
dialogue until moving to another page first.
