### PR TITLE
feat(Opp): allow the ability to change the opportunity name

### DIFF
--- a/src/root/Opp/index.js
+++ b/src/root/Opp/index.js
@@ -60,7 +60,8 @@ const Fetch = component => sources => {
 }
 
 const _Title = sources => ResponsiveTitle({...sources,
-  titleDOM$: sources.opp$.pluck('name'),
+  // don't fail if there is no opp name
+  titleDOM$: sources.opp$.pluck('name').filter(Boolean).startWith(''),
   subtitleDOM$: combineLatest(
     sources.isMobile$, sources.pageTitle$,
     (isMobile, pageTitle) => isMobile ? pageTitle : null,


### PR DESCRIPTION
Fixes error AL was having with creating an opportunity with an empty string for a name, while allowing the user to edit the existing name.