### PR TITLE
Tylors/fix/hide unconfirmable engagements

### DIFF
--- a/src/root/Dash/Doing.js
+++ b/src/root/Dash/Doing.js
@@ -37,6 +37,19 @@ const _Fetch = sources => {
   const acceptedEngagements$ = engagements$
     .map(engagements => engagements.filter(e => !!e.isAccepted && !e.isPaid))
 
+  // gets opportunities associated with accepted Engagements
+  const acceptedOpportunities$ = acceptedEngagements$
+    .map(engagements => engagements.map(e => e.oppKey).map(Opps.query.one(sources)))
+    .map(combineLatest)
+    .switch()
+
+  // filter out engagements associated with opportunities that do not have confirmations on
+  const engagementsToConfirm$ =
+    combineLatest(acceptedEngagements$, acceptedOpportunities$,
+      (engagements, opportunities) =>
+        engagements.filter((e, i) => opportunities[i].confirmationsOn)
+    )
+
   const organizers$ = sources.userProfileKey$
     .flatMapLatest(Organizers.query.byUser(sources))
     .shareReplay(1)
@@ -64,6 +77,7 @@ const _Fetch = sources => {
     engagements$,
     organizers$,
     acceptedEngagements$,
+    engagementsToConfirm$,
   }
 }
 
@@ -142,7 +156,7 @@ const ConfirmListItem = sources => {
 }
 
 const ConfirmationsList = sources => PartialList({...sources,
-  rows$: sources.acceptedEngagements$,
+  rows$: sources.engagementsToConfirm$,
   Control$: just(ConfirmListItem),
 })
 
@@ -150,10 +164,13 @@ const approvedMsg =
   `You've been approved for these opportunities. ` +
   `Confirm now to lock in your spot!`
 
+const noConfirmations =
+  `You currently have no opportunities to confirm.`
+
 const ConfirmationsNeededCard = sources => {
   const list = ConfirmationsList(sources)
   const contents$ = list.contents$
-    .map(contents => [approvedMsg, ...contents])
+    .map(contents => [contents.length ? approvedMsg : noConfirmations, ...contents])
   const card = hideable(TitledCard)({...sources,
     elevation$: just(2),
     isVisible$: sources.acceptedEngagements$.map(c => c.length > 0),

--- a/src/root/Engagement/Priority/index.js
+++ b/src/root/Engagement/Priority/index.js
@@ -2,6 +2,7 @@ import {Observable} from 'rx'
 const {merge} = Observable
 
 import {combineDOMsToDiv} from 'util'
+import {Opps} from 'components/remote'
 import {complement, not, prop, propEq, allPass} from 'ramda'
 
 import isolate from '@cycle/isolate'
@@ -33,7 +34,10 @@ export default sources => {
   const applied = hideable(CardApplied)({...sources,
     isVisible$: sources.engagement$.map(isApplied),
   })
-  const confirm = isolate(CardConfirmNow)(sources)
+
+  const confirm = hideable(isolate(CardConfirmNow))({...sources,
+    isVisible$: sources.opp$.map(o => !!o.confirmationsOn),
+  })
   const r2w = isolate(CardUpcomingShifts)(sources)
   const pms = isolate(CardPickMoreShifts)(sources)
   const ee = isolate(CardEnergyExchange)(sources)

--- a/src/root/Opp/index.js
+++ b/src/root/Opp/index.js
@@ -60,7 +60,8 @@ const Fetch = component => sources => {
 }
 
 const _Title = sources => ResponsiveTitle({...sources,
-  titleDOM$: sources.opp$.pluck('name'),
+  // don't fail if there is no opp name
+  titleDOM$: sources.opp$.pluck('name').filter(Boolean).startWith(''),
   subtitleDOM$: combineLatest(
     sources.isMobile$, sources.pageTitle$,
     (isMobile, pageTitle) => isMobile ? pageTitle : null,


### PR DESCRIPTION
Quick fix for hiding engagements that are associated with opportunities that do not yet allow confirmations.