### PR TITLE
feat(csv): generate csvs

### DIFF
--- a/src/components/SwitchedComponent.js
+++ b/src/components/SwitchedComponent.js
@@ -7,6 +7,7 @@ const sinks = [
   'focus$',
   'openAndPrint',
   'openGraph',
+  'csv$',
 ]
 
 /**

--- a/src/drivers/csv.js
+++ b/src/drivers/csv.js
@@ -1,0 +1,17 @@
+import {Observable} from 'rx'
+
+export function csvDriver(csv$) {
+  csv$.subscribe(csv => {
+    const blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'})
+    const link = document.createElement('a')
+    const url = URL.createObjectURL(blob)
+    link.setAttribute('href', url)
+    link.setAttribute('download', 'sparks-admin.csv')
+    link.style.visibility = 'hidden'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  })
+
+  return Observable.never()
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,25 +1,27 @@
-/* global Sparks */
-import {run} from '@cycle/core'
-
-// drivers
-import {makeDOMDriver} from 'cycle-snabbdom'
-import defaultModules from 'cycle-snabbdom/lib/modules'
-import SupernovaModule from 'drivers/supernova'
-import {makeRouterDriver, supportsHistory} from 'cyclic-router'
-import {createHistory, createHashHistory} from 'history'
-import firebase from 'firebase'
+import {createHashHistory, createHistory} from 'history'
 import {
-  makeAuthDriver, makeFirebaseDriver, makeQueueDriver,
+  makeAuthDriver,
+  makeFirebaseDriver,
+  makeQueueDriver,
 } from '@sparksnetwork/cyclic-fire'
-import screenInfoDriver from 'drivers/screenInfo'
-import makeOpenAndPrintDriver from 'drivers/openAndPrint'
-import makeBugsnagDriver from 'drivers/bugsnag'
-import makeFocusNextDriver from 'drivers/focusNext'
-import makePrerenderDriver from 'drivers/prerender'
-import makeOpenGraphDriver from 'drivers/openGraph'
+import {makeRouterDriver, supportsHistory} from 'cyclic-router'
 
 // app root function
 import Root from './root'
+import SupernovaModule from 'drivers/supernova'
+import {csvDriver} from 'drivers/csv'
+import defaultModules from 'cycle-snabbdom/lib/modules'
+import firebase from 'firebase'
+import makeBugsnagDriver from 'drivers/bugsnag'
+// drivers
+import {makeDOMDriver} from 'cycle-snabbdom'
+import makeFocusNextDriver from 'drivers/focusNext'
+import makeOpenAndPrintDriver from 'drivers/openAndPrint'
+import makeOpenGraphDriver from 'drivers/openGraph'
+import makePrerenderDriver from 'drivers/prerender'
+/* global Sparks */
+import {run} from '@cycle/core'
+import screenInfoDriver from 'drivers/screenInfo'
 
 const history = supportsHistory() ?
   createHistory() : createHashHistory()
@@ -51,6 +53,7 @@ const {sources, sinks} = run(Root, {
   openAndPrint: makeOpenAndPrintDriver('#root'),
   prerender: makePrerenderDriver(),
   openGraph: makeOpenGraphDriver(),
+  csv: csvDriver,
 })
 
 if (module.hot) {

--- a/src/root/Admin/CSV.js
+++ b/src/root/Admin/CSV.js
@@ -1,0 +1,102 @@
+import {Engagements, Opps, Profiles, Projects} from 'components/remote'
+import {always, cond, filter, has, join, map, pipe, prop, toPairs} from 'ramda'
+
+import {List} from 'components/sdm'
+import {Observable} from 'rx'
+import {ProjectItem} from 'components/project'
+import combineLatestObj from 'rx-combine-latest-obj'
+import {div} from 'cycle-snabbdom'
+
+const {just} = Observable
+
+// converts an array of arrays to an array of strings
+const toCsv = arr => `"${join('","', arr)}"\n`
+
+const toRecord = ([key,vals]) => ({key, ...vals})
+
+const toRows = pipe(toPairs, map(toRecord))
+
+const filterOrphans = pipe(filter(has('profileKey')), filter(has('oppKey')))
+
+const statusCode = cond([
+  [prop('declined'), always('REJECTED')],
+  [prop('isConfirmed'), always('CONFIRMED')],
+  [prop('isAccepted'), always('ACCEPTED')],
+  [prop('isApplied'), always('APPLIED')],
+])
+
+const lensFields = ({key, profile, project, opp, ...eng}) => [
+  eng.profileKey,
+  profile.fullName,
+  profile.email,
+  profile.phone,
+  key,
+  statusCode(eng),
+  eng.amountPaid || '0.00',
+  opp.projectKey,
+  project.name,
+  eng.oppKey,
+  opp.name,
+]
+
+export default sources => {
+  console.clear()
+
+  const projects$ = Projects.query.all(sources)().shareReplay(1)
+
+  const engagements$ = Engagements.query.all(sources)()
+    .map(pipe(toRows, filterOrphans))
+    .map(filter(eng => !!eng || !!eng.oppKey || !!eng.profileKey))
+    .map(map(engagement => {
+      const projectAndOpp$ = Opps.query.one(sources)(engagement.oppKey)
+        .map(opp => {
+          const project$ = projects$
+            .map(filter(prj => prj.$key === opp.projectKey)) //eslint-disable-line
+            .map(prjs => prjs[0] || {}) //eslint-disable-line
+
+          return project$.map(project => ({ project, opp })) // eslint-disable-line
+        })
+        .switch()
+
+      const profile$ = Profiles.query.one(sources)(engagement.profileKey)
+
+      return Observable.combineLatest(projectAndOpp$, profile$)
+        .map(([{project, opp}, profile]) =>
+          ({key: engagement.$key, project, opp, profile, ...engagement}))
+    }))
+    .map(Observable.combineLatest)
+    .switch()
+    .shareReplay(1)
+
+  const projectList = List({...sources,
+    Control$: just(ProjectItem),
+    rows$: projects$,
+  })
+
+  const route$ = Observable.merge(
+    projectList.route$,
+    Projects.redirect.create(sources).route$,
+  )
+
+  const key$ = route$.map(route => route.split('/project/')[1].trim())
+
+  const csv$ = Observable.combineLatest(engagements$, key$)
+    .map(([engagements, key]) => {
+      return engagements
+        .filter(engagement => engagement.opp.projectKey === key)
+        .map(pipe(lensFields, toCsv))
+        .join('')
+    })
+
+  const viewState = {
+    listDOM$: projectList.DOM,
+  }
+
+  const DOM = combineLatestObj(viewState)
+    .map(({listDOM}) => div({},[listDOM]))
+
+  return {
+    DOM,
+    csv$,
+  }
+}

--- a/src/root/Admin/CSV.js
+++ b/src/root/Admin/CSV.js
@@ -40,8 +40,6 @@ const lensFields = ({key, profile, project, opp, ...eng}) => [
 ]
 
 export default sources => {
-  console.clear()
-
   const projects$ = Projects.query.all(sources)().shareReplay(1)
 
   const engagements$ = Engagements.query.all(sources)()

--- a/src/root/Admin/index.js
+++ b/src/root/Admin/index.js
@@ -1,19 +1,15 @@
+import AppFrame from 'components/AppFrame'
+import CSV from './CSV'
+import ComingSoon from 'components/ComingSoon'
+import Header from 'components/Header'
 import {Observable} from 'rx'
+import Profiles from './Profiles'
+import Projects from './Projects'
+import {TabbedPage} from 'components/ui'
+import Title from 'components/Title'
+import {mergeSinks} from 'util'
 const {of} = Observable
 // import combineLatestObj from 'rx-combine-latest-obj'
-
-import AppFrame from 'components/AppFrame'
-import Title from 'components/Title'
-import Header from 'components/Header'
-
-import {mergeSinks} from 'util'
-
-import ComingSoon from 'components/ComingSoon'
-
-import Projects from './Projects'
-import Profiles from './Profiles'
-
-import {TabbedPage} from 'components/ui'
 
 const _Nav = sources => ({
   DOM: sources.isMobile$.map(m => m ? null : sources.titleDOM),
@@ -29,13 +25,13 @@ const _Page = sources => TabbedPage({...sources,
     {path: '/', label: 'Projects'},
     {path: '/profiles', label: 'Profiles'},
     {path: '/previously', label: 'Previously'},
-    {path: '/test', label: 'Test'},
+    {path: '/csv', label: 'CSV'},
   ]),
   routes$: of({
     '/': Projects,
     '/profiles': Profiles,
     '/previously': ComingSoon('Admin/Previously'),
-    '/test': ComingSoon('Admin/Test'),
+    '/csv': CSV,
   }),
 })
 

--- a/src/root/index.js
+++ b/src/root/index.js
@@ -1,43 +1,46 @@
-import {Observable as $} from 'rx'
-const {just, merge} = $
-
-import isolate from '@cycle/isolate'
-import {propOr, pick, join, compose, omit} from 'ramda'
-
-import {
-  AuthRoute,
-  AuthedKeyRoute,
-  KeyRoute,
-  AuthRedirectManager,
-  AuthedResponseManager,
-  UserManager,
-} from 'helpers/auth'
-
-import Login from './Login'
-import Logout from './Logout'
-import Confirm from './Confirm'
-import Dash from './Dash'
-import Admin from './Admin'
-import Project from './Project'
-import Team from './Team'
-import Opp from './Opp'
-import Apply from './Apply'
-import ApplyToOpp from './ApplyToOpp'
-import Engagement from './Engagement'
-import Organize from './Organize'
-
 import 'normalize-css'
 import 'snabbdom-material/lib/index.css'
-
-import {siteUrl} from 'util'
-
-import {RoutedComponent} from 'components/ui'
-import {SwitchedComponent} from 'components/SwitchedComponent'
-
-import {log} from 'util'
-import {div} from 'helpers'
-
 import './styles.scss'
+
+import {
+  AuthRedirectManager,
+  AuthRoute,
+  AuthedKeyRoute,
+  AuthedResponseManager,
+  KeyRoute,
+  UserManager,
+} from 'helpers/auth'
+import {compose, join, omit, pick, propOr} from 'ramda'
+
+import {Observable as $} from 'rx'
+import Admin from './Admin'
+import Apply from './Apply'
+import ApplyToOpp from './ApplyToOpp'
+import Confirm from './Confirm'
+import Dash from './Dash'
+import Engagement from './Engagement'
+import Login from './Login'
+import Logout from './Logout'
+import Opp from './Opp'
+import Organize from './Organize'
+import Project from './Project'
+import {RoutedComponent} from 'components/ui'
+import {SideNav} from './SideNav'
+import {SwitchedComponent} from 'components/SwitchedComponent'
+import Team from './Team'
+import {div} from 'helpers'
+import isolate from '@cycle/isolate'
+import {log} from 'util'
+import {siteUrl} from 'util'
+const {just, merge} = $
+
+
+
+
+
+
+
+
 
 // Route definitions at this level
 const _routes = {
@@ -58,7 +61,6 @@ const _routes = {
   '/logout': Logout,
 }
 
-import {SideNav} from './SideNav'
 
 const BlankSidenav = () => ({
   DOM: just(div('')),
@@ -142,6 +144,7 @@ const Root = sources => {
     bugsnag,
     openAndPrint: page.openAndPrint,
     openGraph,
+    csv: page.csv$,
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,13 +1,24 @@
-import {Observable} from 'rx'
-import {ReplaySubject} from 'rx'
-const {just, combineLatest, empty} = Observable
 import {
-  complement, compose, curryN, filter, isNil, join, map, objOf, prop, toPairs,
+  complement,
+  compose,
+  curryN,
+  filter,
+  isNil,
+  join,
+  map,
+  objOf,
+  prop,
+  toPairs,
 } from 'ramda'
 
+import {Observable} from 'rx'
+import {ReplaySubject} from 'rx'
 import {div} from 'helpers'
-
 import isolate from '@cycle/isolate'
+import moment from 'moment'
+const {just, combineLatest, empty} = Observable
+
+
 
 export const PROVIDERS = {
   google: {type: 'redirect', provider: 'google', scopes: [
@@ -18,7 +29,6 @@ export const PROVIDERS = {
   logout: {type: 'logout'},
 }
 
-import moment from 'moment'
 
 export const hideable = Control => sources => {
   const ctrl = Control(sources)
@@ -221,6 +231,7 @@ export const mergeSinks = (...childs) => ({
   focus$: mergeOrFlatMapLatest('focus$', ...childs),
   openAndPrint: mergeOrFlatMapLatest('openAndPrint', ...childs),
   openGraph: mergeOrFlatMapLatest('openGraph', ...childs),
+  csv$: mergeOrFlatMapLatest('csv$', ...childs),
 })
 
 export const pluckLatest = (k,s$) => s$.pluck(k).switch()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
-import path from 'path'
-import webpack from 'webpack'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import importUrl from 'postcss-import-url'
+import path from 'path'
+import webpack from 'webpack'
 
 const DEV = 'development'
 const ENV = process.env.BUILD_ENV || DEV
@@ -51,7 +51,7 @@ const entry = {
   ],
 }
 
-const devtool = ENV === DEV ? 'cheap-module-eval-source-map' : 'hidden-source-map'
+const devtool = ENV === DEV ? 'hidden-source-map' : 'hidden-source-map'
 
 function extractOrNot(fallback, loader) {
   if (ENV === 'development') {


### PR DESCRIPTION
Allow feature of generating CSVs for admins only.
By navigating to /admin/csv you will be provided a list of projects,
identical to /admin/projects minus the project creation field. When an admin
clicks on one of the projects a csv will be generated and downloaded as sparks-admin.csv
which will increment based on your browsers download behavior. e.g sparks-admin(1).csv the
second time you download and sparks-admin(2).csv the third etc.